### PR TITLE
fix: 修复并不优雅的“优雅退出”

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,6 @@ async def message_process():
         else:
             logger.warning(f"未知的post_type: {post_type}")
         message_queue.task_done()
-        await asyncio.sleep(0.05)
 
 
 async def main():

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 import json
 import http
+import signal
 import websockets as Server
 from src.logger import logger
 from src.recv_handler.message_handler import message_handler
@@ -14,6 +15,7 @@ from src.mmc_com_layer import mmc_start_com, mmc_stop_com, router
 from src.response_pool import put_response, check_timeout_response
 
 message_queue = asyncio.Queue()
+server: Server.Server = None
 
 
 async def message_recv(server_connection: Server.ServerConnection):
@@ -50,6 +52,7 @@ async def main():
     message_send_instance.maibot_router = router
     _ = await asyncio.gather(napcat_server(), mmc_start_com(), message_process(), check_timeout_response())
 
+
 def check_napcat_server_token(conn, request):
     token = global_config.napcat_server.token
     if not token or token.strip() == "":
@@ -59,45 +62,84 @@ def check_napcat_server_token(conn, request):
         return Server.Response(
             status=http.HTTPStatus.UNAUTHORIZED,
             headers=Server.Headers([("Content-Type", "text/plain")]),
-            body=b"Unauthorized\n"
+            body=b"Unauthorized\n",
         )
     return None
 
+
 async def napcat_server():
+    global server
     logger.info("正在启动adapter...")
-    async with Server.serve(message_recv, global_config.napcat_server.host, global_config.napcat_server.port, max_size=2**26, process_request=check_napcat_server_token) as server:
-        logger.info(
-            f"Adapter已启动，监听地址: ws://{global_config.napcat_server.host}:{global_config.napcat_server.port}"
-        )
-        await server.serve_forever()
+    server = await Server.serve(
+        message_recv,
+        global_config.napcat_server.host,
+        global_config.napcat_server.port,
+        max_size=2**26,
+        process_request=check_napcat_server_token,
+    )
+    logger.info(f"Adapter已启动，监听地址: ws://{global_config.napcat_server.host}:{global_config.napcat_server.port}")
+    await server.wait_closed()
 
 
-async def graceful_shutdown():
-    try:
-        logger.info("正在关闭adapter...")
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+async def graceful_shutdown(loop: asyncio.AbstractEventLoop, timeout: float = 10.0):
+    logger.info("正在关闭adapter...")
+
+    # 主动关闭所有 websocket 连接
+    if server and server.is_serving() and server.connections:
+        logger.info(f"正在关闭 {len(server.connections)} 个客户端连接...")
+        close_tasks = [conn.close() for conn in server.connections]
+        await asyncio.gather(*close_tasks, return_exceptions=True)
+
+    # 关闭服务器，停止接受新连接
+    if server and server.is_serving():
+        logger.info("正在关闭 Websocket 服务器...")
+        server.close()
+        await server.wait_closed()
+        logger.info("Websocket 服务器已关闭")
+
+    # 关闭 aiohttp 客户端
+    await mmc_stop_com()
+    logger.info("MMC com layer 已停止")
+
+    # 取消所有其他任务
+    tasks = [t for t in asyncio.all_tasks(loop=loop) if t is not asyncio.current_task()]
+    if tasks:
+        logger.info(f"正在取消 {len(tasks)} 个剩余任务...")
         for task in tasks:
-            if not task.done():
-                task.cancel()
-        await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 15)
-        await mmc_stop_com()  # 后置避免神秘exception
-        logger.info("Adapter已成功关闭")
-    except Exception as e:
-        logger.error(f"Adapter关闭中出现错误: {e}")
+            task.cancel()
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info("所有剩余任务已处理完毕")
+
+    logger.info("Adapter 已成功关闭")
 
 
 if __name__ == "__main__":
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
+    shutdown_event = asyncio.Event()
+
+    def _shutdown_handler(sig: int):
+        logger.warning(f"收到信号 {signal.Signals(sig).name}，开始关闭...")
+        shutdown_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _shutdown_handler, sig)
+        except NotImplementedError:
+            pass  # Windows
+
     try:
-        loop.run_until_complete(main())
-    except KeyboardInterrupt:
-        logger.warning("收到中断信号，正在优雅关闭...")
-        loop.run_until_complete(graceful_shutdown())
-    except Exception as e:
-        logger.exception(f"主程序异常: {str(e)}")
-        sys.exit(1)
+        main_task = loop.create_task(main())
+        loop.run_until_complete(shutdown_event.wait())
     finally:
+        logger.info("开始优雅关闭流程...")
+
+        # 执行新的关机流程
+        loop.run_until_complete(graceful_shutdown(loop=loop))
+
+        # 最终关闭循环
         if loop and not loop.is_closed():
             loop.close()
+        logger.info("程序已退出")
         sys.exit(0)


### PR DESCRIPTION
### 问题描述
当前版本的ada在接收到 `SIGINT` 信号后，进程会卡死，必须发送第二次 `SIGINT` 信号才能强制终止。

问题的根源在于程序依赖 `try...except KeyboardInterrupt` 这种脆弱的方式来处理退出信号，并在关闭时暴力使用 `task.cancel()` 来取消所有任务。这种方法会引发竞争条件 (race conditions)，导致 `asyncio` 任务在未完成清理的情况下被中断，从而使整个事件循环卡死。

### 解决思路
所以引入了 `asyncio` 应用程序标准的生命周期管理方式，从根本上解决了关闭问题。

1.  标准化信号处理：废弃 `try...except KeyboardInterrupt` 的反模式，改而通过 `loop.add_signal_handler()` 为 `SIGINT` 和 `SIGTERM` 信号注册了专用的处理器。这是在 `asyncio` 中处理关闭信号的正确实践。它将外部信号转化为程序内部可控的事件，而不是异常。

2.  状态驱动的关闭流程：增加了一个 `asyncio.Event` (`shutdown_event`) 作为关闭信号。主程序不再被动地等待异常，而是主动地等待这个事件被设置。这使得程序的生命周期（运行 -> 等待关闭 -> 开始关闭）变得清晰、明确且无竞争条件。

3.  有序地优雅关闭：新的 `graceful_shutdown` 函数定义了清晰、正确的关闭顺序：
    * 主动关闭所有活跃的 websocket 连接。
    * 关闭 websocket 服务器，停止接受新连接。
    * 清理其他异步组件 (如 `mmc_com_layer`)。
    * 取消剩余的后台任务。

4.  删除无用代码：移除 `await asyncio.sleep(0.05)` 这一行。
**理由是**: `await message_queue.get()` 在队列为空时，本身就是一个**非阻塞的等待**，它会自动将执行权交还给事件循环。在处理完消息后强行增加一个 `sleep` 是完全多余的，它人为地制造了一个性能瓶颈，将消息处理速度限制在最高 20条/秒。移除它能让程序在消息高峰期发挥出最大的处理能力。
